### PR TITLE
Allow only truststore to be set

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,14 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Tests
+        run: make test

--- a/.helmignore
+++ b/.helmignore
@@ -1,1 +1,3 @@
 *.png
+tests
+Makefile

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 name: vertica-kafka-scheduler
 description: Deploys the Vertica Kafka Scheduler in Kubernetes
 type: application
-version: 0.1.3
+version: 0.1.4
 # The appVersion corresponds to the Vertica version
 appVersion: "23.4.0"
 icon: https://raw.githubusercontent.com/vertica/kafka-scheduler-chart/main/vertica-logo.png

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+HELM_UNITTEST_VERSION?=3.9.3-0.2.11
+
+.PHONY: test
+test: ## Run the helm unittest
+	docker run -i $(shell [ -t 0 ] && echo '-t') --rm -v .:/apps quintush/helm-unittest:$(HELM_UNITTEST_VERSION) -3 .

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ This helm chart will deploy the vertica kafka scheduler. It will deploy the vert
 | tls.enabled | If true, we setup with the assumption that TLS authentication will be used. | false |
 | tls.keyStoreMountPath | Directory name where the keystore will be mounted in the pod | |
 | tls.keyStorePassword | The password to use along with the keystore | |
-| tls.keyStoreSecretKey | A key within the tls.keyStoreSecretName that will be used as the keystore file name | |
+| tls.keyStoreSecretKey | A key within the tls.keyStoreSecretName that will be used as the keystore file name. If this is omitted, then no keystore information is included. | |
 | tls.keyStoreSecretName | Name of an existing Secret that contains the keystore | |
 | tls.trustStoreMountPath | Directory name where the truststore will be mounted in the pod | |
 | tls.trustStoreSecretKey | A key within tls.trustStoreSecretName that will be used as the truststore file name | |
-| tls.trustStoreSecretName | Name of an existing Secret that contains the truststore | |
+| tls.trustStoreSecretName | Name of an existing Secret that contains the truststore. If this is omitted, then no truststore information is included. | |
 | tolerations | Tolerations to use with the pods to control where it is scheduled | |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -104,7 +104,7 @@ Generate te value for VKCONFIG_JVM_OPTS based on values.yaml
 */}}
 {{- define "vertica-kafka-scheduler.jvmOpts" -}}
 {{- if .Values.tls.enabled -}}
-"-Djavax.net.ssl.trustStore={{ .Values.tls.trustStoreMountPath }}/{{ .Values.tls.trustStoreSecretKey }} -Djavax.net.ssl.keyStore={{ .Values.tls.keyStoreMountPath }}/{{ .Values.tls.keyStoreSecretKey }} -Djavax.net.ssl.keyStorePassword={{ .Values.tls.keyStorePassword }} {{ .Values.jvmOpts }}"
+"{{- if .Values.tls.trustStoreSecretName -}}-Djavax.net.ssl.trustStore={{ .Values.tls.trustStoreMountPath }}/{{ .Values.tls.trustStoreSecretKey }}{{- end -}}{{- if .Values.tls.keyStoreSecretName -}}  -Djavax.net.ssl.keyStore={{ .Values.tls.keyStoreMountPath }}/{{ .Values.tls.keyStoreSecretKey }} -Djavax.net.ssl.keyStorePassword={{ .Values.tls.keyStorePassword }} {{ .Values.jvmOpts }}{{- end -}}"
 {{- else -}}
 {{ default (quote "") .Values.jvmOpts }}
 {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -45,10 +45,14 @@ spec:
           - name: vkconfig
             mountPath: /opt/vertica/packages/kafka/config
           {{- if .Values.tls.enabled }}
+          {{- if .Values.tls.trustStoreMountPath }}
           - name: truststore
             mountPath: {{ .Values.tls.trustStoreMountPath }}
+          {{- end }}
+          {{- if .Values.tls.keyStoreMountPath }}
           - name: keystore
             mountPath: {{ .Values.tls.keyStoreMountPath }}
+          {{- end }}
           {{- end }}
           env:
           - name: VKCONFIG_JVM_OPTS
@@ -60,12 +64,16 @@ spec:
         configMap:
           name: {{ include "vertica-kafka-scheduler.configmap-fullname" . }}
       {{- if .Values.tls.enabled }}
+      {{- if .Values.tls.trustStoreSecretName }}
       - name: truststore
         secret:
           secretName: {{ .Values.tls.trustStoreSecretName }}
+      {{- end }}
+      {{- if .Values.tls.keyStoreSecretName }}
       - name: keystore
         secret:
           secretName: {{ .Values.tls.keyStoreSecretName }}
+      {{- end }}
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/tests/tls_test.yaml
+++ b/tests/tls_test.yaml
@@ -1,0 +1,123 @@
+suite: TLS tests
+templates:
+- deployment.yaml
+tests:
+- it: should not have any JVM opts set if TLS is disabled
+  set:
+    tls.enabled: false
+    launcherEnabled: true
+  asserts:
+  - isKind:
+      of: Deployment
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VKCONFIG_JVM_OPTS
+        value: ""
+- it: should have JVM opts set if TLS is configured with all opts
+  set:
+    tls:
+      enabled: true
+      trustStoreMountPath: /truststore
+      trustStoreSecretKey: truststore
+      trustStoreSecretName: trust-store-secret
+      keyStoreMountPath: /keystore
+      keyStoreSecretKey: keystore
+      keyStorePassword: pwd
+      keyStoreSecretName: key-store-secret
+    launcherEnabled: true
+  asserts:
+  - isKind:
+      of: Deployment
+  - contains:
+      path: spec.template.spec.volumes
+      content:
+        name: truststore
+        secret:
+          secretName: trust-store-secret
+  - contains:
+      path: spec.template.spec.volumes
+      content:
+        name: keystore
+        secret:
+          secretName: key-store-secret
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VKCONFIG_JVM_OPTS
+        value: '-Djavax.net.ssl.trustStore=/truststore/truststore-Djavax.net.ssl.keyStore=/keystore/keystore -Djavax.net.ssl.keyStorePassword=pwd '
+- it: should have JVM opts set if TLS is configured with just truststore
+  set:
+    tls:
+      enabled: true
+      trustStoreMountPath: /truststore
+      trustStoreSecretKey: truststore
+      trustStoreSecretName: trust-store-secret
+    launcherEnabled: true
+  asserts:
+  - isKind:
+      of: Deployment
+  - contains:
+      path: spec.template.spec.volumes
+      content:
+        name: truststore
+        secret:
+          secretName: trust-store-secret
+  - notContains:
+      path: spec.template.spec.volumes
+      any: true
+      content:
+        name: keystore
+  - contains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: truststore
+        mountPath: /truststore
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      any: true
+      content:
+        name: keystore
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VKCONFIG_JVM_OPTS
+        value: '-Djavax.net.ssl.trustStore=/truststore/truststore'
+- it: should have JVM opts set if TLS is configured with just keystore
+  set:
+    tls:
+      enabled: true
+      keyStoreMountPath: /keystore
+      keyStoreSecretKey: keystore
+      keyStoreSecretName: keystore-secret
+      keyStorePassword: my-secret
+    launcherEnabled: true
+  asserts:
+  - isKind:
+      of: Deployment
+  - notContains:
+      path: spec.template.spec.volumes
+      any: true
+      content:
+        name: truststore
+  - contains:
+      path: spec.template.spec.volumes
+      content:
+        name: keystore
+        secret:
+          secretName: keystore-secret
+  - notContains:
+      path: spec.template.spec.containers[0].volumeMounts
+      any: true
+      content:
+        name: truststore
+  - contains:
+      path: spec.template.spec.containers[0].volumeMounts
+      content:
+        name: keystore
+        mountPath: /keystore
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VKCONFIG_JVM_OPTS
+        value: '-Djavax.net.ssl.keyStore=/keystore/keystore -Djavax.net.ssl.keyStorePassword=my-secret '


### PR DESCRIPTION
Previously when setting up tls you had to specify both the keystore and truststore. Now, either one can be specified. 