### PR TITLE
Update to initializer for truststore only deployments

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 name: vertica-kafka-scheduler
 description: Deploys the Vertica Kafka Scheduler in Kubernetes
 type: application
-version: 0.1.4
+version: 0.1.5
 # The appVersion corresponds to the Vertica version
 appVersion: "23.4.0"
 icon: https://raw.githubusercontent.com/vertica/kafka-scheduler-chart/main/vertica-logo.png

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -104,7 +104,7 @@ Generate te value for VKCONFIG_JVM_OPTS based on values.yaml
 */}}
 {{- define "vertica-kafka-scheduler.jvmOpts" -}}
 {{- if .Values.tls.enabled -}}
-"{{- if .Values.tls.trustStoreSecretName -}}-Djavax.net.ssl.trustStore={{ .Values.tls.trustStoreMountPath }}/{{ .Values.tls.trustStoreSecretKey }}{{- end -}}{{- if .Values.tls.keyStoreSecretName -}}  -Djavax.net.ssl.keyStore={{ .Values.tls.keyStoreMountPath }}/{{ .Values.tls.keyStoreSecretKey }} -Djavax.net.ssl.keyStorePassword={{ .Values.tls.keyStorePassword }} {{ .Values.jvmOpts }}{{- end -}}"
+"{{ if .Values.tls.trustStoreSecretName }}-Djavax.net.ssl.trustStore={{ .Values.tls.trustStoreMountPath }}/{{ .Values.tls.trustStoreSecretKey }}{{ end }}{{ if .Values.tls.keyStoreSecretName }} -Djavax.net.ssl.keyStore={{ .Values.tls.keyStoreMountPath }}/{{ .Values.tls.keyStoreSecretKey }} -Djavax.net.ssl.keyStorePassword={{ .Values.tls.keyStorePassword }} {{ .Values.jvmOpts }}{{ end }}"
 {{- else -}}
 {{ default (quote "") .Values.jvmOpts }}
 {{- end }}

--- a/templates/pod.yaml
+++ b/templates/pod.yaml
@@ -29,10 +29,14 @@ spec:
       - name: vkconfig
         mountPath: /opt/vertica/packages/kafka/config
       {{- if .Values.tls.enabled }}
+      {{- if .Values.tls.trustStoreSecretName }}
       - name: truststore
         mountPath: {{ .Values.tls.trustStoreMountPath }}
+      {{- end }}
+      {{- if .Values.tls.keyStoreSecretName }}
       - name: keystore
         mountPath: {{ .Values.tls.keyStoreMountPath }}
+      {{- end }}
       {{- end }}
       env:
       - name: VKCONFIG_JVM_OPTS
@@ -44,12 +48,16 @@ spec:
     configMap:
       name: {{ include "vertica-kafka-scheduler.configmap-fullname" . }}
   {{- if .Values.tls.enabled }}
+  {{- if .Values.tls.trustStoreSecretName }}
   - name: truststore
     secret:
       secretName: {{ .Values.tls.trustStoreSecretName }}
+  {{- end }}
+  {{- if .Values.tls.keyStoreSecretName }}
   - name: keystore
     secret:
       secretName: {{ .Values.tls.keyStoreSecretName }}
+  {{- end }}
   {{- end }}
   {{- with .Values.nodeSelector }}
   nodeSelector:

--- a/tests/pod_test.yaml
+++ b/tests/pod_test.yaml
@@ -1,0 +1,42 @@
+suite: Pod tests
+templates:
+- pod.yaml
+tests:
+- it: should not include keystore volume if only truststore enabled for TLS
+  set:
+    tls:
+      enabled: true
+      trustStoreMountPath: /truststore
+      trustStoreSecretKey: trust-store.jks
+      trustStoreSecretName: truststore-jks
+    launcherEnabled: true
+  asserts:
+  - isKind:
+      of: Pod
+  - contains:
+      path: spec.containers[0].env
+      content:
+        name: VKCONFIG_JVM_OPTS
+        value: "-Djavax.net.ssl.trustStore=/truststore/trust-store.jks"
+  - contains:
+      path: spec.volumes
+      content:
+        name: truststore
+        secret:
+          secretName: truststore-jks
+  - notContains:
+      path: spec.volumes
+      any: true
+      content:
+        name: keystore
+  - contains:
+      path: spec.containers[0].volumeMounts
+      content:
+        name: truststore
+        mountPath: /truststore
+  - notContains:
+      path: spec.containers[0].volumeMounts
+      any: true
+      content:
+        name: keystore
+

--- a/tests/tls_test.yaml
+++ b/tests/tls_test.yaml
@@ -45,7 +45,7 @@ tests:
       path: spec.template.spec.containers[0].env
       content:
         name: VKCONFIG_JVM_OPTS
-        value: '-Djavax.net.ssl.trustStore=/truststore/truststore-Djavax.net.ssl.keyStore=/keystore/keystore -Djavax.net.ssl.keyStorePassword=pwd '
+        value: '-Djavax.net.ssl.trustStore=/truststore/truststore -Djavax.net.ssl.keyStore=/keystore/keystore -Djavax.net.ssl.keyStorePassword=pwd '
 - it: should have JVM opts set if TLS is configured with just truststore
   set:
     tls:
@@ -120,4 +120,4 @@ tests:
       path: spec.template.spec.containers[0].env
       content:
         name: VKCONFIG_JVM_OPTS
-        value: '-Djavax.net.ssl.keyStore=/keystore/keystore -Djavax.net.ssl.keyStorePassword=my-secret '
+        value: ' -Djavax.net.ssl.keyStore=/keystore/keystore -Djavax.net.ssl.keyStorePassword=my-secret '


### PR DESCRIPTION
Previous fix wasn't complete as I forgot to update the initializer pod. I am also fixing the VKCONFIG_JVM_OPTS, which didn't have correct spacing.