### PR TITLE
Allow a password to be supplied for the truststore

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 name: vertica-kafka-scheduler
 description: Deploys the Vertica Kafka Scheduler in Kubernetes
 type: application
-version: 0.1.5
+version: 0.1.6
 # The appVersion corresponds to the Vertica version
 appVersion: "23.4.0"
 icon: https://raw.githubusercontent.com/vertica/kafka-scheduler-chart/main/vertica-logo.png

--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ This helm chart will deploy the vertica kafka scheduler. It will deploy the vert
 | serviceAccount.create | If true, a ServiceAccount is created as part of the deployment | true |
 | serviceAccount.name | Name of the service account. If not set and create is true, a name is generated using the fullname template | |
 | tls.enabled | If true, we setup with the assumption that TLS authentication will be used. | false |
-| tls.keyStoreMountPath | Directory name where the keystore will be mounted in the pod | |
-| tls.keyStorePassword | The password to use along with the keystore | |
-| tls.keyStoreSecretKey | A key within the tls.keyStoreSecretName that will be used as the keystore file name. If this is omitted, then no keystore information is included. | |
-| tls.keyStoreSecretName | Name of an existing Secret that contains the keystore | |
-| tls.trustStoreMountPath | Directory name where the truststore will be mounted in the pod | |
-| tls.trustStoreSecretKey | A key within tls.trustStoreSecretName that will be used as the truststore file name | |
+| tls.keyStoreMountPath | Directory name where the keystore will be mounted in the pod. This controls the name of the keystore within the pod. The full path to the keystore will be constructed by combining this parameter with tls.keyStoreSecretKey. | |
+| tls.keyStorePassword | The password to use along with the keystore. If omitted, then no password is used. | |
+| tls.keyStoreSecretKey | A key within tls.keyStoreSecretName that will be used as the keystore file name. This is used along with tls.keyStoreMountPath to form the full path to the key in the pod. | |
+| tls.keyStoreSecretName | Name of an existing Secret that contains the keystore. If this is omitted, then no keystore information is included. | |
+| tls.trustStoreMountPath | Directory name where the truststore will be mounted in the pod. This controls the name of the truststore within the pod. The full path to the truststore will be constructed by combining this parameter with tls.trustStoreSecretKey. | |
+| tls.trustStorePassword | The password to use along with the truststore. If omitted, then no password is used. | |
+| tls.trustStoreSecretKey | A key within tls.trustStoreSecretName that will be used as the truststore file name. This is used along with tls.trustStoreMountPath to form the full path to the key in the pod. | |
 | tls.trustStoreSecretName | Name of an existing Secret that contains the truststore. If this is omitted, then no truststore information is included. | |
 | tolerations | Tolerations to use with the pods to control where it is scheduled | |

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -103,9 +103,31 @@ Create the name of the service account to use
 Generate te value for VKCONFIG_JVM_OPTS based on values.yaml
 */}}
 {{- define "vertica-kafka-scheduler.jvmOpts" -}}
+{{- $opts := list ( include "vertica-kafka-scheduler.trustStore" . ) ( include "vertica-kafka-scheduler.trustStorePassword" . ) ( include "vertica-kafka-scheduler.keyStore" . ) ( include "vertica-kafka-scheduler.keyStorePassword" . ) .Values.jvmOpts -}}
+{{- $opts := compact $opts -}}
+{{ join " " $opts | quote }}
+{{- end }}
+
+{{- define "vertica-kafka-scheduler.trustStore" -}}
 {{- if .Values.tls.enabled -}}
-"{{ if .Values.tls.trustStoreSecretName }}-Djavax.net.ssl.trustStore={{ .Values.tls.trustStoreMountPath }}/{{ .Values.tls.trustStoreSecretKey }}{{ end }}{{ if .Values.tls.keyStoreSecretName }} -Djavax.net.ssl.keyStore={{ .Values.tls.keyStoreMountPath }}/{{ .Values.tls.keyStoreSecretKey }} -Djavax.net.ssl.keyStorePassword={{ .Values.tls.keyStorePassword }} {{ .Values.jvmOpts }}{{ end }}"
-{{- else -}}
-{{ default (quote "") .Values.jvmOpts }}
-{{- end }}
-{{- end }}
+{{ if .Values.tls.trustStoreSecretName }}-Djavax.net.ssl.trustStore={{ .Values.tls.trustStoreMountPath }}/{{ .Values.tls.trustStoreSecretKey }}{{ end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "vertica-kafka-scheduler.trustStorePassword" -}}
+{{- if .Values.tls.enabled -}}
+{{ if .Values.tls.trustStorePassword }}-Djavax.net.ssl.trustStorePassword={{ .Values.tls.trustStorePassword }}{{ end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "vertica-kafka-scheduler.keyStore" -}}
+{{- if .Values.tls.enabled -}}
+{{ if .Values.tls.keyStoreSecretName }}-Djavax.net.ssl.keyStore={{ .Values.tls.keyStoreMountPath }}/{{ .Values.tls.keyStoreSecretKey }}{{ end }}
+{{- end -}}
+{{- end -}}
+
+{{- define "vertica-kafka-scheduler.keyStorePassword" -}}
+{{- if .Values.tls.enabled -}}
+{{ if .Values.tls.keyStorePassword }}-Djavax.net.ssl.keyStorePassword={{ .Values.tls.keyStorePassword }}{{ end -}}
+{{- end -}}
+{{- end -}}

--- a/tests/tls_test.yaml
+++ b/tests/tls_test.yaml
@@ -14,6 +14,19 @@ tests:
       content:
         name: VKCONFIG_JVM_OPTS
         value: ""
+- it: should have only JVM opts set if TLS is disabled
+  set:
+    tls.enabled: false
+    jvmOpts: "-Dspecial-fix=true"
+    launcherEnabled: true
+  asserts:
+  - isKind:
+      of: Deployment
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VKCONFIG_JVM_OPTS
+        value: "-Dspecial-fix=true"
 - it: should have JVM opts set if TLS is configured with all opts
   set:
     tls:
@@ -45,7 +58,7 @@ tests:
       path: spec.template.spec.containers[0].env
       content:
         name: VKCONFIG_JVM_OPTS
-        value: '-Djavax.net.ssl.trustStore=/truststore/truststore -Djavax.net.ssl.keyStore=/keystore/keystore -Djavax.net.ssl.keyStorePassword=pwd '
+        value: '-Djavax.net.ssl.trustStore=/truststore/truststore -Djavax.net.ssl.keyStore=/keystore/keystore -Djavax.net.ssl.keyStorePassword=pwd'
 - it: should have JVM opts set if TLS is configured with just truststore
   set:
     tls:
@@ -120,4 +133,40 @@ tests:
       path: spec.template.spec.containers[0].env
       content:
         name: VKCONFIG_JVM_OPTS
-        value: ' -Djavax.net.ssl.keyStore=/keystore/keystore -Djavax.net.ssl.keyStorePassword=my-secret '
+        value: '-Djavax.net.ssl.keyStore=/keystore/keystore -Djavax.net.ssl.keyStorePassword=my-secret'
+- it: should concatenate custom JVM opts from TLS config
+  set:
+    tls:
+      enabled: true
+      keyStoreMountPath: /keystore
+      keyStoreSecretKey: keystore
+      keyStoreSecretName: keystore-secret
+      keyStorePassword: my-secret
+    jvmOpts: "-Dmy-special-opt"
+    launcherEnabled: true
+  asserts:
+  - isKind:
+      of: Deployment
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VKCONFIG_JVM_OPTS
+        value: '-Djavax.net.ssl.keyStore=/keystore/keystore -Djavax.net.ssl.keyStorePassword=my-secret -Dmy-special-opt'
+- it: should allow truststore password to be set in TLS config
+  set:
+    tls:
+      enabled: true
+      trustStoreMountPath: /truststore
+      trustStoreSecretKey: my-truststore.jks
+      trustStoreSecretName: trust-store-secret
+      trustStorePassword: abcdef123
+    launcherEnabled: true
+    jvmOpts: "-Dextra-opt"
+  asserts:
+  - isKind:
+      of: Deployment
+  - contains:
+      path: spec.template.spec.containers[0].env
+      content:
+        name: VKCONFIG_JVM_OPTS
+        value: '-Djavax.net.ssl.trustStore=/truststore/my-truststore.jks -Djavax.net.ssl.trustStorePassword=abcdef123 -Dextra-opt'

--- a/values.schema.json
+++ b/values.schema.json
@@ -111,43 +111,40 @@
                     "default": false
                 },
                 "trustStoreSecretName": {
-                    "description": "Name of a preexisting Secret that contains the truststore to use.",
+                    "description": "Name of an existing Secret that contains the keystore. If this is omitted, then no keystore information is included.",
                     "type": "string"
                 },
                 "trustStoreMountPath": {
-                    "description": "The directory mount for the trustStoreSecretName",
+                    "description": "Directory name where the truststore will be mounted in the pod. This controls the name of the truststore within the pod. The full path to the truststore will be constructed by combining this parameter with trustStoreSecretKey.",
                     "type": "string"
                 },
                 "trustStoreSecretKey": {
-                    "description": "The key within trustStoreSecretName that has the truststore to use. This will be mounted as a file within the pod",
+                    "description": "A key within tls.trustStoreSecretName that will be used as the truststore file name. This is used along with tls.trustStoreMountPath to form the full path to the key in the pod.",
+                    "type": "string"
+                },
+                "trustStorePassword": {
+                    "description": "The password to use along with the truststore. If omitted, then no password is used.",
                     "type": "string"
                 },
                 "keyStoreSecretName": {
-                    "description": "Name of a preexisting Secret that contains the keystore to use",
+                    "description": "Name of an existing Secret that contains the keystore. If this is omitted, then no keystore informiation is included.",
                     "type": "string"
                 },
                 "keyStoreMountPath": {
-                    "description": "The directory mount for the keyStoreSecretName",
+                    "description": "Directory name where the keystore will be mounted in the pod. This controls the name of the keystore within the pod. The full path to the keystore will be constructed by combining this parameter with keyStoreSecretKey.",
                     "type": "string"
                 },
                 "keyStoreSecretKey": {
-                    "description": "The key within keyStoreSecretName that has the keystore to use. This will be mounted as a file within the pod.",
+                    "description": "A key within keyStoreSecretName that will be used as the keystore file name. This is used along with tls.keyStoreMountPath to form the full path to the key in the pod.",
                     "type": "string"
                 },
                 "keyStorePassword": {
-                    "description": "The password to access the keystore",
+                    "description": "The password to use along with the keystore. If omitted, then no password is used.",
                     "type": "string"
                 }
             },
             "required": [
-                "enabled",
-                "keyStoreMountPath",
-                "keyStorePassword",
-                "keyStoreSecretKey",
-                "keyStoreSecretName",
-                "trustStoreMountPath",
-                "trustStoreSecretKey",
-                "trustStoreSecretName"
+                "enabled"
             ],
             "title": "TLS"
         },

--- a/values.yaml
+++ b/values.yaml
@@ -80,6 +80,8 @@ tls:
   # The key within trustStoreSecretName that has the truststore to use. This
   # will be mounted as a file within the pod.
   trustStoreSecretKey: ""
+  # The password to access the truststore
+  trustStorePassword: ""
   # Name of a preexisting Secret that contains the keystore to use.
   keyStoreSecretName: ""
   # The next two control the name of the key store. The path will be:


### PR DESCRIPTION
This adds a new helm chart parameter to allow you to specify a password for the truststore.

This also fixes a bug where the extra JVM opts were not included if specified.