### PR TITLE
Allow timezone to be selected for the logging output

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ apiVersion: v2
 name: vertica-kafka-scheduler
 description: Deploys the Vertica Kafka Scheduler in Kubernetes
 type: application
-version: 0.1.7
+version: 0.1.8
 # The appVersion corresponds to the Vertica version
 appVersion: "24.1.0"
 icon: https://raw.githubusercontent.com/vertica/kafka-scheduler-chart/main/vertica-logo.png

--- a/README.md
+++ b/README.md
@@ -344,6 +344,10 @@ Now that you have a containerized Kafka cluster and VerticaDB CR running, you ca
   <dt>serviceAccount.name</dt>
     <dd>Name of the <a href="https://kubernetes.io/docs/concepts/security/service-accounts/">service account</a>. If this parameter is not set and <code>serviceAccount.create</code> is set to <code>true</code>, a name is generated using the fullname template.</dd>
 
+  <dt>timezone</dt>
+    <dd>Utilize this to manage the timezone of the logger. As logging employs log4j, ensure you use a Java-friendly timezone ID. Refer to this site for available IDs: https://docs.oracle.com/middleware/1221/wcs/tag-ref/MISC/TimeZones.html</dd>
+    <dd><b>Default</b>: UTC</dd>
+
   <dt>tls.enabled</dt>
     <dd>When set to <code>true</code>, the scheduler is set up for TLS authentication.</dd>
     <dd><b>Default</b>: <code>false</code></dd>

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -17,7 +17,7 @@ data:
         
         <Console name="stdout" target="SYSTEM.OUT">
           <PatternLayout>
-            <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} [%X{PID}:%t] %logger::%t %X{tuple} [%p] %m%n</Pattern>
+            <Pattern>%d{yyyy-MM-dd HH:mm:ss.SSS}{{ printf "{%s}" .Values.timezone }} [%X{PID}:%t] %logger::%t %X{tuple} [%p] %m%n</Pattern>
           </PatternLayout>
         </Console>
 

--- a/values.schema.json
+++ b/values.schema.json
@@ -152,6 +152,11 @@
             "description": "Controls the setting of VKCONFIG_JVM_OPTS in the pods. Values for truststore and keystore are added automatically based on the tls.* values",
             "type": "string"
         },
+        "timezone": {
+            "description": "Utilize this to manage the timezone of the logger. As logging employs log4j, ensure you use a Java-friendly timezone ID. Refer to this site for available IDs: https://docs.oracle.com/middleware/1221/wcs/tag-ref/MISC/TimeZones.html",
+            "type": "string",
+            "default": "UTC"
+        },
         "serviceAccount": {
             "type": "object",
             "additionalProperties": false,

--- a/values.yaml
+++ b/values.yaml
@@ -99,6 +99,11 @@ tls:
 # and keystore are added automatically based on the tls.* values.
 jvmOpts: ""
 
+# Utilize this to manage the timezone of the logger. As logging employs log4j,
+# ensure you use a Java-friendly timezone ID. Refer to this site for available
+# IDs: https://docs.oracle.com/middleware/1221/wcs/tag-ref/MISC/TimeZones.html
+timezone: UTC
+
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
The timezone for the logger can now be selected using the helm chart parameter 'timezone'. As logging employs log4j, ensure you use a Java-friendly timezone ID. Refer to this site for available IDs: https://docs.oracle.com/middleware/1221/wcs/tag-ref/MISC/TimeZones.html

For example, to use time from Halifax, you would run: 
```
helm install k vertica-charts/kafka-scheduler-chart --set timezone="America/Halifax"
```